### PR TITLE
[backport25] Add the root lock blocker

### DIFF
--- a/lib/Controller/LockingController.php
+++ b/lib/Controller/LockingController.php
@@ -90,6 +90,12 @@ class LockingController extends OCSController {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to create the lock'));
 		}
 
+		if ($userFolder->getId() === $id) {
+			$e = new OCSForbiddenException($this->l10n->t('You are not allowed to lock the root'));
+			$this->logger->error($e->getMessage(), ['exception' => $e]);
+			throw $e;
+		}
+
 		$nodes = $userFolder->getById($id);
 		if (!isset($nodes[0]) || !$nodes[0] instanceof Folder) {
 			throw new OCSForbiddenException($this->l10n->t('You are not allowed to create the lock'));

--- a/lib/Controller/LockingController.php
+++ b/lib/Controller/LockingController.php
@@ -91,9 +91,7 @@ class LockingController extends OCSController {
 		}
 
 		if ($userFolder->getId() === $id) {
-			$e = new OCSForbiddenException($this->l10n->t('You are not allowed to lock the root'));
-			$this->logger->error($e->getMessage(), ['exception' => $e]);
-			throw $e;
+			throw new OCSForbiddenException($this->l10n->t('You are not allowed to lock the root'));
 		}
 
 		$nodes = $userFolder->getById($id);


### PR DESCRIPTION
When being in trouble with locked root folders, Nextcloud implemented a blocker for root locks.
The blocker is included in upstream with stable26, but lacking in stable25.

Thus, added for V25 as backport.