### PR TITLE
[backport28] Hardcode default setting to delete files on key change

### DIFF
--- a/src/components/SecuritySection.vue
+++ b/src/components/SecuritySection.vue
@@ -76,7 +76,7 @@ export default {
 			hasKey: loadState('end_to_end_encryption', 'hasKey'),
 			shouldDisplayWarning: false,
 			modal: false,
-			deleteEncryptedFiles: false,
+			deleteEncryptedFiles: true, // this is actually the only change to standard settings; TODO: upstream Nextcloud
 		}
 	},
 	computed: {


### PR DESCRIPTION
The default should be to delete files on key change for MagentaCLOUD.
Nextcloud finds the deletion of files counter-intuitive.

Mid-term, we should have the possibility to configure the default implemented on upstream.
We can implement a proposal in this branch.